### PR TITLE
Rails 5 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omnicontacts (0.3.5)
+    omnicontacts (0.3.9)
       json
       rack
 
@@ -9,7 +9,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.3)
-    json (1.8.1)
+    json (1.8.3)
     multi_json (1.1.0)
     rack (1.4.1)
     rack-test (0.6.1)
@@ -37,3 +37,6 @@ DEPENDENCIES
   rake
   rspec
   simplecov
+
+BUNDLED WITH
+   1.10.6

--- a/lib/omnicontacts.rb
+++ b/lib/omnicontacts.rb
@@ -1,6 +1,6 @@
 module OmniContacts
   
-  VERSION = "0.3.5"
+  VERSION = "0.3.9"
 
   MOUNT_PATH = "/contacts/"
 

--- a/lib/omnicontacts/http_utils.rb
+++ b/lib/omnicontacts/http_utils.rb
@@ -57,7 +57,7 @@ module OmniContacts
     # If the result of ssl_ca_file is nil no file is used. In this case a warn message is logged.
     private
 
-    # Executes an HTTP GET request. 
+    # Executes an HTTP GET request.
     # It raises a RuntimeError if the response code is not equal to 200
     def http_get host, path, params
       connection = Net::HTTP.new(host)

--- a/lib/omnicontacts/importer.rb
+++ b/lib/omnicontacts/importer.rb
@@ -4,7 +4,9 @@ module OmniContacts
     autoload :Gmail, "omnicontacts/importer/gmail"
     autoload :Yahoo, "omnicontacts/importer/yahoo"
     autoload :Hotmail, "omnicontacts/importer/hotmail"
+    autoload :Outlook, "omnicontacts/importer/outlook"
     autoload :Facebook, "omnicontacts/importer/facebook"
+    autoload :Linkedin, "omnicontacts/importer/linkedin"
 
   end
 end

--- a/lib/omnicontacts/importer/facebook.rb
+++ b/lib/omnicontacts/importer/facebook.rb
@@ -13,12 +13,12 @@ module OmniContacts
         super *args
         @auth_host = 'graph.facebook.com'
         @authorize_path = '/oauth/authorize'
-        @scope = 'email,user_relationships,user_birthday,friends_birthday'
+        @scope = 'email,user_relationships,user_birthday,user_friends'
         @auth_token_path = '/oauth/access_token'
         @contacts_host = 'graph.facebook.com'
-        @friends_path = '/me/friends'
-        @family_path = '/me/family'
-        @self_path = '/me'
+        @friends_path = '/v2.5/me/friends'
+        @family_path = '/v2.5/me/family'
+        @self_path = '/v2.5/me'
       end
 
       def fetch_contacts_using_access_token access_token, access_token_secret

--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -13,18 +13,18 @@ module OmniContacts
         @auth_host = "accounts.google.com"
         @authorize_path = "/o/oauth2/auth"
         @auth_token_path = "/o/oauth2/token"
-        @scope = "https://www.google.com/m8/feeds https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
+        @scope = (args[3] && args[3][:scope]) || "https://www.googleapis.com/auth/contacts.readonly https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
         @contacts_host = "www.google.com"
         @contacts_path = "/m8/feeds/contacts/default/full"
         @max_results =  (args[3] && args[3][:max_results]) || 100
         @self_host = "www.googleapis.com"
-        @profile_path = "/oauth2/v1/userinfo"
+        @profile_path = "/oauth2/v3/userinfo"
       end
 
       def fetch_contacts_using_access_token access_token, token_type
         fetch_current_user(access_token, token_type)
         contacts_response = https_get(@contacts_host, @contacts_path, contacts_req_params, contacts_req_headers(access_token, token_type))
-        contacts_from_response contacts_response
+        contacts_from_response(contacts_response, access_token)
       end
 
       def fetch_current_user access_token, token_type
@@ -43,8 +43,9 @@ module OmniContacts
         {"GData-Version" => "3.0", "Authorization" => "#{token_type} #{token}"}
       end
 
-      def contacts_from_response response_as_json
+      def contacts_from_response(response_as_json, access_token)
         response = JSON.parse(response_as_json)
+
         return [] if response['feed'].nil? || response['feed']['entry'].nil?
         contacts = []
         return contacts if response.nil?
@@ -55,18 +56,16 @@ module OmniContacts
                       :first_name => nil,
                       :last_name => nil,
                       :name => nil,
-                      :email => nil,
+                      :emails => nil,
                       :gender => nil,
                       :birthday => nil,
                       :profile_picture=> nil,
                       :relation => nil,
-                      :address_1 => nil,
-                      :address_2 => nil,
-                      :city => nil,
-                      :region => nil,
-                      :country => nil,
-                      :postcode => nil,
-                      :phone_number => nil
+                      :addresses => nil,
+                      :phone_numbers => nil,
+                      :dates => nil,
+                      :company => nil,
+                      :position => nil
           }
           contact[:id] = entry['id']['$t'] if entry['id']
           if entry['gd$name']
@@ -77,9 +76,20 @@ module OmniContacts
             contact[:name] = full_name(contact[:first_name],contact[:last_name]) if contact[:name].nil?
           end
 
-          contact[:email] = entry['gd$email'][0]['address'] if entry['gd$email']
+          contact[:emails] = []
+          entry['gd$email'].each do |email|
+            if email['rel']
+              split_index = email['rel'].index('#')
+              contact[:emails] << {:name => email['rel'][split_index + 1, email['rel'].length - 1], :email => email['address']}
+            elsif email['label']
+              contact[:emails] << {:name => email['label'], :email => email['address']}
+            end
+          end if entry['gd$email']
+
+          # Support older versions of the gem by keeping singular entries around
+          contact[:email] = contact[:emails][0][:email] if contact[:emails][0]
           contact[:first_name], contact[:last_name], contact[:name] = email_to_name(contact[:name]) if !contact[:name].nil? && contact[:name].include?('@')
-          contact[:first_name], contact[:last_name], contact[:name] = email_to_name(contact[:email]) if contact[:name].nil? && contact[:email]
+          contact[:first_name], contact[:last_name], contact[:name] = email_to_name(contact[:emails][0][:email]) if (contact[:name].nil? && contact[:emails][0] && contact[:emails][0][:email])
           #format - year-month-date
           contact[:birthday] = birthday(entry['gContact$birthday']['when'])  if entry['gContact$birthday']
 
@@ -94,28 +104,76 @@ module OmniContacts
             end
           end
 
-          address = entry['gd$structuredPostalAddress'][0] if entry['gd$structuredPostalAddress']
-          if address
-            contact[:address_1] = address['gd$street']['$t'] if address['gd$street']
-            contact[:address_1] = address['gd$formattedAddress']['$t'] if contact[:address_1].nil? && address['gd$formattedAddress']
-            if contact[:address_1].index("\n")
-              parts = contact[:address_1].split("\n")
-              contact[:address_1] = parts.first
-              # this may contain city/state/zip if user jammed it all into one string.... :-(
-              contact[:address_2] = parts[1..-1].join(', ')
+          contact[:addresses] = []
+          entry['gd$structuredPostalAddress'].each do |address|
+            if address['rel']
+              split_index = address['rel'].index('#')
+              new_address = {:name => address['rel'][split_index + 1, address['rel'].length - 1]}
+            elsif address['label']
+              new_address = {:name => address['label']}
             end
-            contact[:city] = address['gd$city']['$t'] if address['gd$city']
-            contact[:region] = address['gd$region']['$t'] if address['gd$region'] # like state or province
-            contact[:country] = address['gd$country']['code'] if address['gd$country']
-            contact[:postcode] = address['gd$postcode']['$t'] if address['gd$postcode']
-          end
-          contact[:phone_number] =  entry["gd$phoneNumber"][0]['$t'] if entry["gd$phoneNumber"]
 
-          if entry['gContact$website'] && entry['gContact$website'][0]["rel"] == "profile"
-            contact[:id] = contact_id(entry['gContact$website'][0]["href"])
-            contact[:profile_picture] = image_url(contact[:id])
-          else
-            contact[:profile_picture] = image_url_from_email(contact[:email])
+            new_address[:address_1] = address['gd$street']['$t'] if address['gd$street']
+            new_address[:address_1] = address['gd$formattedAddress']['$t'] if new_address[:address_1].nil? && address['gd$formattedAddress']
+            if !new_address[:address_1].nil? && new_address[:address_1].index("\n")
+              parts = new_address[:address_1].split("\n")
+              new_address[:address_1] = parts.first
+              # this may contain city/state/zip if user jammed it all into one string.... :-(
+              new_address[:address_2] = parts[1..-1].join(', ')
+            end
+            new_address[:city] = address['gd$city']['$t'] if address['gd$city']
+            new_address[:region] = address['gd$region']['$t'] if address['gd$region'] # like state or province
+            new_address[:country] = address['gd$country']['code'] if address['gd$country']
+            new_address[:postcode] = address['gd$postcode']['$t'] if address['gd$postcode']
+            contact[:addresses] << new_address
+          end if entry['gd$structuredPostalAddress']
+
+          # Support older versions of the gem by keeping singular entries around
+          if contact[:addresses][0]
+            contact[:address_1] = contact[:addresses][0][:address_1]
+            contact[:address_2] = contact[:addresses][0][:address_2]
+            contact[:city] = contact[:addresses][0][:city]
+            contact[:region] = contact[:addresses][0][:region]
+            contact[:country] = contact[:addresses][0][:country]
+            contact[:postcode] = contact[:addresses][0][:postcode]
+          end
+
+          contact[:phone_numbers] = []
+          entry['gd$phoneNumber'].each do |phone_number|
+            if phone_number['rel']
+              split_index = phone_number['rel'].index('#')
+              contact[:phone_numbers] << {:name => phone_number['rel'][split_index + 1, phone_number['rel'].length - 1], :number => phone_number['$t']}
+            elsif phone_number['label']
+              contact[:phone_numbers] << {:name => phone_number['label'], :number => phone_number['$t']}
+            end
+          end if entry['gd$phoneNumber']
+
+          # Support older versions of the gem by keeping singular entries around
+          contact[:phone_number] = contact[:phone_numbers][0][:number] if contact[:phone_numbers][0]
+
+          if entry["link"] && entry["link"].is_a?(Array)
+            entry["link"].each do |link|
+              if link["type"] == 'image/*' && link["gd$etag"]
+                contact[:profile_picture] = link["href"] + "?&access_token=" + access_token
+                break
+              end
+            end
+          end
+
+          if entry['gContact$event']
+            contact[:dates] = []
+            entry['gContact$event'].each do |event|
+              if event['rel']
+                contact[:dates] << {:name => event['rel'], :date => birthday(event['gd$when']['startTime'])}
+              elsif event['label']
+                contact[:dates] << {:name => event['label'], :date => birthday(event['gd$when']['startTime'])}
+              end
+            end
+          end
+
+          if entry['gd$organization']
+            contact[:company] = entry['gd$organization'][0]['gd$orgName']['$t'] if entry['gd$organization'][0]['gd$orgName']
+            contact[:position] = entry['gd$organization'][0]['gd$orgTitle']['$t'] if entry['gd$organization'][0]['gd$orgTitle']
           end
 
           contacts << contact if contact[:name]
@@ -124,15 +182,11 @@ module OmniContacts
         contacts
       end
 
-      def image_url gmail_id
-        return "https://profiles.google.com/s2/photos/profile/" + gmail_id if gmail_id
-      end
-
       def current_user me, access_token, token_type
         return nil if me.nil?
         me = JSON.parse(me)
         user = {:id => me['id'], :email => me['email'], :name => me['name'], :first_name => me['given_name'],
-                :last_name => me['family_name'], :gender => me['gender'], :birthday => birthday(me['birthday']), :profile_picture => image_url(me['id']),
+                :last_name => me['family_name'], :gender => me['gender'], :birthday => birthday(me['birthday']), :profile_picture => me["picture"],
                 :access_token => access_token, :token_type => token_type
         }
         user

--- a/lib/omnicontacts/importer/hotmail.rb
+++ b/lib/omnicontacts/importer/hotmail.rb
@@ -11,10 +11,10 @@ module OmniContacts
 
       def initialize app, client_id, client_secret, options ={}
         super app, client_id, client_secret, options
-        @auth_host = "oauth.live.com"
-        @authorize_path = "/authorize"
-        @scope = options[:permissions] || "wl.signin, wl.basic, wl.birthday , wl.emails ,wl.contacts_birthday , wl.contacts_photos"
-        @auth_token_path = "/token"
+        @auth_host = "login.live.com"
+        @authorize_path = "/oauth20_authorize.srf"
+        @scope = options[:permissions] || "wl.signin, wl.basic, wl.birthday , wl.emails ,wl.contacts_birthday , wl.contacts_photos, wl.contacts_emails"
+        @auth_token_path = "/oauth20_token.srf"
         @contacts_host = "apis.live.net"
         @contacts_path = "/v5.0/me/contacts"
         @self_path = "/v5.0/me"
@@ -41,14 +41,10 @@ module OmniContacts
           # creating nil fields to keep the fields consistent across other networks
           contact = {:id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil, :gender => nil, :birthday => nil, :profile_picture=> nil, :relation => nil, :email_hashes => []}
           contact[:id] = entry['user_id'] ? entry['user_id'] : entry['id']
-          if valid_email? entry["name"]
-            contact[:email] = entry["name"]
-            contact[:first_name], contact[:last_name], contact[:name] = email_to_name(contact[:email])
-          else
-            contact[:first_name] = normalize_name(entry['first_name'])
-            contact[:last_name] = normalize_name(entry['last_name'])
-            contact[:name] = normalize_name(entry['name'])
-          end
+	        contact[:email] = parse_email(entry['emails']) if valid_email? parse_email(entry['emails'])
+	        contact[:first_name] = normalize_name(entry['first_name'])
+	        contact[:last_name] = normalize_name(entry['last_name'])
+	        contact[:name] = normalize_name(entry['name'])
           contact[:birthday] = birthday_format(entry['birth_month'], entry['birth_day'], entry['birth_year'])
           contact[:gender] = entry['gender']
           contact[:profile_picture] = image_url(entry['user_id'])
@@ -60,7 +56,7 @@ module OmniContacts
 
       def parse_email(emails)
         return nil if emails.nil?
-        emails['account']
+        emails['account'] || emails['preferred'] || emails['personal'] || emails['business'] || emails['other']
       end
 
       def current_user me

--- a/lib/omnicontacts/importer/linkedin.rb
+++ b/lib/omnicontacts/importer/linkedin.rb
@@ -1,0 +1,63 @@
+require "omnicontacts/parse_utils"
+require "omnicontacts/middleware/oauth2"
+
+module OmniContacts
+  module Importer
+    class Linkedin < Middleware::OAuth2
+      include ParseUtils
+
+      attr_reader :auth_host, :authorize_path, :auth_token_path, :scope, :state
+
+      def initialize *args
+        super *args
+        @auth_host = "www.linkedin.com"
+        @authorize_path = "/uas/oauth2/authorization"
+        @auth_token_path = "/uas/oauth2/accessToken"
+        @scope = (args[3] && args[3][:scope]) || "r_network"
+        @contacts_host = "api.linkedin.com"
+        @contacts_path = "/v1/people/~/connections:(id,first-name,last-name,picture-url)"
+        @self_host = "www.linkedin.com"
+        @profile_path = "/oauth2/v1/userinfo"
+        @state = (args[3] && args[3][:state])
+      end
+
+      def fetch_contacts_using_access_token access_token, token_type
+        token_type = "Bearer" if token_type.nil?
+        contacts_response = https_get(@contacts_host, @contacts_path, contacts_req_params, contacts_req_headers(access_token, token_type))
+        contacts_from_response contacts_response
+      end
+
+      private
+
+      def contacts_req_params
+        {'format' => 'json'}
+      end
+
+      def contacts_req_headers token, token_type
+        {"Authorization" => "#{token_type} #{token}"}
+      end
+
+      def contacts_from_response response_as_json
+        response = JSON.parse(response_as_json)
+        return [] if response['values'].nil?
+        contacts = []
+        return contacts if response.nil?
+        response['values'].map do |entry|
+          {
+           id: entry['id'],
+            first_name: normalize_name(entry['firstName']),
+            last_name: normalize_name(entry['lastName']),
+            name: full_name(entry['firstName'],entry['lastName']),
+            profile_picture: entry['pictureUrl']
+          }
+        end
+      end
+
+      def authorize_url_params
+        # merge state param required by LinkedIn
+        _params = super
+        _params += "&" + to_query_string(state: @state)
+      end
+    end
+  end
+end

--- a/lib/omnicontacts/importer/outlook.rb
+++ b/lib/omnicontacts/importer/outlook.rb
@@ -1,0 +1,112 @@
+require "omnicontacts/middleware/oauth2"
+require "omnicontacts/parse_utils"
+require "json"
+
+# API Docs: https://msdn.microsoft.com/en-us/office/office365/api/api-catalog#Outlookcontacts
+module OmniContacts
+  module Importer
+    class Outlook < Middleware::OAuth2
+      include ParseUtils
+
+      attr_reader :auth_host, :authorize_path, :auth_token_path, :scope
+
+      def initialize app, client_id, client_secret, options ={}
+        super app, client_id, client_secret, options
+        @auth_host = "login.microsoftonline.com"
+        @authorize_path = "/common/oauth2/v2.0/authorize"
+        @scope = options[:permissions] || "https://outlook.office.com/contacts.read"
+        @auth_token_path = "/common/oauth2/v2.0/token"
+        @contacts_host = "outlook.office.com"
+        @contacts_path = "/api/v2.0/me/contacts"
+        @self_path = "/api/v2.0/me"
+      end
+
+      def fetch_contacts_using_access_token access_token, token_type
+        fetch_current_user(access_token, token_type)
+        contacts_response = https_get(@contacts_host, @contacts_path, {}, contacts_req_headers(access_token, token_type))
+        contacts_from_response contacts_response
+      end
+
+      def fetch_current_user access_token, token_type
+        self_response = https_get(@contacts_host, @self_path, {}, contacts_req_headers(access_token, token_type))
+        user = current_user self_response
+        set_current_user user
+      end
+
+      private
+
+      def contacts_req_headers token, token_type
+        { "Authorization" => "#{token_type} #{token}" }
+      end
+
+      def current_user me
+        return nil if me.nil?
+        me = JSON.parse(me)
+
+        name_splitted = me["DisplayName"].split(" ")
+        first_name = name_splitted.first
+        last_name = name_splitted.last if name_splitted.size > 1
+
+        user = empty_contact
+        user[:id]         = me["Id"]
+        user[:email]      = me["EmailAddress"]
+        user[:name]       = me["DisplayName"]
+        user[:first_name] = normalize_name(first_name)
+        user[:last_name]  = normalize_name(last_name)
+        user
+      end
+
+      def contacts_from_response response_as_json
+        response = JSON.parse(response_as_json)
+        contacts = []
+        response["value"].each do |entry|
+          contact = empty_contact
+          # Full fields reference:
+          # https://msdn.microsoft.com/office/office365/api/complex-types-for-mail-contacts-calendar#RESTAPIResourcesContact
+          contact[:id]         = entry["Id"]
+          contact[:first_name] = entry["GivenName"]
+          contact[:last_name]  = entry["Surname"]
+          contact[:name]       = entry["DisplayName"]
+          contact[:email]      = parse_email(entry["EmailAddresses"])
+          contact[:birthday]   = birthday(entry["Birthday"])
+
+          address = [entry["HomeAddress"], entry["BusinessAddress"], entry["OtherAddress"]].reject(&:empty?).first
+          if address
+            contact[:address_1] = address["Street"]
+            contact[:city]      = address["City"]
+            contact[:region]    = address["State"]
+            contact[:postcode]  = address["PostalCode"]
+            contact[:country]   = address["CountryOrRegion"]
+          end
+
+          contacts << contact if contact[:name] || contact[:first_name]
+        end
+        contacts
+      end
+
+      def empty_contact
+        { :id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil,
+          :gender => nil, :birthday => nil, :profile_picture => nil, :address_1 => nil,
+          :address_2 => nil, :city => nil, :region => nil, :postcode => nil, :relation => nil }
+      end
+
+      def parse_email emails
+        return nil if emails.nil?
+        emails.map! { |email| email["Address"] }
+        emails.select! { |email| valid_email? email }
+        emails.first
+      end
+
+      def birthday dob
+        return nil if dob.nil?
+        birthday = dob[0..9].split("-")
+        birthday[0] = nil if birthday[0].to_i < 1900 # if year is not set it returns 1604
+        return birthday_format(birthday[1], birthday[2], birthday[0])
+      end
+
+      def valid_email? value
+        /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/.match(value)
+      end
+    end
+  end
+end

--- a/lib/omnicontacts/integration_test.rb
+++ b/lib/omnicontacts/integration_test.rb
@@ -2,28 +2,30 @@ require 'singleton'
 
 class IntegrationTest
   include Singleton
-  
+
   attr_accessor :enabled
-  
+
   def initialize
     enabled = false
     clear_mocks
   end
-  
+
   def clear_mocks
-    @mock = {}
+    @user_mocks = {}
+    @contact_mocks = {}
   end
-  
-  def mock provider, mock
-    @mock[provider.to_sym] = mock
+
+  def mock provider, contacts, user = {}
+    @contact_mocks[provider.to_sym] = contacts
+    @user_mocks[provider.to_sym] = user
   end
-  
+
   def mock_authorization_from_user provider
     [302, {"Content-Type" => "application/x-www-form-urlencoded", "location" => provider.redirect_path}, []]
   end
-  
+
   def mock_fetch_contacts provider
-    result = @mock[provider.class_name.to_sym] || []
+    result = @contact_mocks[provider.class_name.to_sym] || []
     if result.is_a? Array
       result
     elsif result.is_a? Hash
@@ -32,5 +34,8 @@ class IntegrationTest
       raise result.to_s
     end
   end
-  
+
+  def mock_fetch_user provider
+    @user_mocks[provider.class_name.to_sym] || {}
+  end
 end

--- a/lib/omnicontacts/middleware/oauth2.rb
+++ b/lib/omnicontacts/middleware/oauth2.rb
@@ -5,7 +5,7 @@ require "omnicontacts/middleware/base_oauth"
 #
 # Extending class are required to implement
 # the following methods:
-# * fetch_contacts_using_access_token -> it 
+# * fetch_contacts_using_access_token -> it
 #   fetches the list of contacts from the authorization
 #   server.
 module OmniContacts
@@ -25,7 +25,7 @@ module OmniContacts
 
       def request_authorization_from_user
         target_url = append_state_query(authorization_url)
-        [302, {"location" => target_url}, []]
+        [302, {"Content-Type" => "application/x-www-form-urlencoded", "location" => target_url}, []]
       end
 
       def redirect_uri
@@ -34,7 +34,7 @@ module OmniContacts
 
       # It extract the authorization code from the query string.
       # It uses it to obtain an access token.
-      # If the authorization code has a refresh token associated 
+      # If the authorization code has a refresh token associated
       # with it in the session, it uses the obtain an access token.
       # It fetches the list of contacts and stores the refresh token
       # associated with the access token in the session.

--- a/omnicontacts.gemspec
+++ b/omnicontacts.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/omnicontacts', __FILE__)
 Gem::Specification.new do |gem|
   gem.name = 'omnicontacts'
   gem.description = %q{A generalized Rack middleware for importing contacts from major email providers.}
-  gem.authors = ['Diego Castorina', 'Jordan Lance']
+  gem.authors = ['Diego Castorina', 'Jordan Lance', 'Asma Tameem', 'Randy Villanueva']
   gem.email = ['diegocastorina@gmail.com', 'voorruby@gmail.com']
 
   gem.add_runtime_dependency 'rack'

--- a/spec/omnicontacts/importer/gmail_spec.rb
+++ b/spec/omnicontacts/importer/gmail_spec.rb
@@ -2,8 +2,22 @@ require "spec_helper"
 require "omnicontacts/importer/gmail"
 
 describe OmniContacts::Importer::Gmail do
-
   let(:gmail) { OmniContacts::Importer::Gmail.new({}, "client_id", "client_secret") }
+
+  let(:gmail_with_scope_args) {
+    OmniContacts::Importer::Gmail.new(
+      {},
+      "client_id",
+      "client_secret",
+      {
+        scope: %w(
+          https://www.googleapis.com/auth/contacts.readonly
+          https://www.googleapis.com/auth/userinfo#email
+          https://www.googleapis.com/auth/userinfo.profile
+        ).join(" ")
+      }
+    )
+  }
 
   let(:self_response) {
     '{
@@ -37,6 +51,8 @@ describe OmniContacts::Importer::Gmail do
 
           "title":{"$t":"Users\'s Contacts"},
           "link":[
+            {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*",
+             "href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/6b41d030b05abc","gd$etag":"\"VSxuN0cISit7I2A1UVUSdy12KHwgBFkE333.\""},
             {"rel":"alternate","type":"text/html","href":"http://www.google.com/"},
             {"rel":"http://schemas.google.com/g/2005#feed","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full"},
             {"rel":"http://schemas.google.com/g/2005#post","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full"},
@@ -58,7 +74,8 @@ describe OmniContacts::Importer::Gmail do
             "category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://schemas.google.com/contact/2008#contact"}],
             "title":{"$t":"Edward Bennet"},
             "link":[
-              {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*","href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/1"},
+              {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*",
+               "href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/6b41d030b05abc", "gd$etag":"\"VSxuN0cISit7I2A1UVUSdy12KHwgBFkE333.\""},
               {"rel":"self","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"},
               {"rel":"edit","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"}
             ],
@@ -67,9 +84,11 @@ describe OmniContacts::Importer::Gmail do
               "gd$givenName":{"$t":"Edward"},
               "gd$familyName":{"$t":"Bennet"}
             },
+            "gd$organization":[{"rel":"http://schemas.google.com/g/2005#other","gd$orgName":{"$t":"Google"},"gd$orgTitle":{"$t":"Master Developer"}}],
             "gContact$birthday":{"when":"1954-07-02"},
             "gContact$relation":{"rel":"father"},
             "gContact$gender":{"value":"male"},
+            "gContact$event":[{"rel":"anniversary","gd$when":{"startTime":"1983-04-21"}},{"label":"New Job","gd$when":{"startTime":"2014-12-01"}}],
             "gd$email":[{"rel":"http://schemas.google.com/g/2005#other","address":"bennet@gmail.com","primary":"true"}],
             "gContact$groupMembershipInfo":[{"deleted":"false","href":"http://www.google.com/m8/feeds/groups/logged_in_user%40gmail.com/base/6"}],
             "gd$structuredPostalAddress":[{"rel":"http://schemas.google.com/g/2005#home","gd$formattedAddress":{"$t":"1313 Trashview Court\nApt. 13\nNowheresville, OK 66666"},"gd$street":{"$t":"1313 Trashview Court\nApt. 13"},"gd$postcode":{"$t":"66666"},"gd$country":{"code":"VA","$t":"Valoran"},"gd$city":{"$t":"Nowheresville"},"gd$region":{"$t":"OK"}}],
@@ -108,6 +127,7 @@ describe OmniContacts::Importer::Gmail do
 
     before(:each) do
       gmail.instance_variable_set(:@env, {})
+      gmail_with_scope_args.instance_variable_set(:@env, {})
     end
 
     it "should request the contacts by specifying version and code in the http headers" do
@@ -122,6 +142,9 @@ describe OmniContacts::Importer::Gmail do
         contacts_as_json
       end
       gmail.fetch_contacts_using_access_token token, token_type
+
+      gmail.scope.should eq "https://www.googleapis.com/auth/contacts.readonly https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
+      gmail_with_scope_args.scope.should eq "https://www.googleapis.com/auth/contacts.readonly https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
     end
 
     it "should correctly parse id, name, email, gender, birthday, profile picture and relation for 1st contact" do
@@ -136,9 +159,10 @@ describe OmniContacts::Importer::Gmail do
       result.first[:name].should eq("Edward Bennet")
       result.first[:email].should eq("bennet@gmail.com")
       result.first[:gender].should eq("male")
-      result.first[:birthday].should eq({:day=>02, :month=>07, :year=>1954})
+      result.first[:birthday].should eq({ :day => 02, :month => 07, :year => 1954 })
       result.first[:relation].should eq('father')
-      result.first[:profile_picture].should eq("https://profiles.google.com/s2/photos/profile/bennet")
+      result.first[:profile_picture].should eq("https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/6b41d030b05abc?&access_token=token")
+      result.first[:dates][0][:name].should eq("anniversary")
     end
 
     it "should correctly parse id, name, email, gender, birthday, profile picture, snailmail address, phone and relation for 2nd contact" do
@@ -152,8 +176,8 @@ describe OmniContacts::Importer::Gmail do
       result.last[:name].should eq("Emilia Fox")
       result.last[:email].should eq("emilia.fox@gmail.com")
       result.last[:gender].should eq("female")
-      result.last[:birthday].should eq({:day=>10, :month=>02, :year=>1974})
-      result.last[:profile_picture].should eq("https://profiles.google.com/s2/photos/profile/emilia.fox")
+      result.last[:birthday].should eq({ :day => 10, :month => 02, :year => 1974 })
+      result.last[:profile_picture].should be_nil
       result.last[:relation].should eq('spouse')
       result.first[:address_1].should eq('1313 Trashview Court')
       result.first[:address_2].should eq('Apt. 13')
@@ -178,8 +202,122 @@ describe OmniContacts::Importer::Gmail do
       user[:name].should eq("Chris Johnson")
       user[:email].should eq("chrisjohnson@gmail.com")
       user[:gender].should eq("male")
-      user[:birthday].should eq({:day=>21, :month=>06, :year=>1982})
-      user[:profile_picture].should eq("https://profiles.google.com/s2/photos/profile/16482944006464829443")
+      user[:birthday].should eq({ :day => 21, :month => 06, :year => 1982 })
+      user[:profile_picture].should eq("https://lh3.googleusercontent.com/-b8aFbTBM/AAAAAAI/IWA/vsek/photo.jpg")
+    end
+
+    context "when address_1 is nil" do
+      let(:contacts_as_json) {
+        '{"version":"1.0","encoding":"UTF-8",
+        "feed":{
+          "xmlns":"http://www.w3.org/2005/Atom",
+          "xmlns$openSearch":"http://a9.com/-/spec/opensearch/1.1/",
+          "xmlns$gContact":"http://schemas.google.com/contact/2008",
+          "xmlns$batch":"http://schemas.google.com/gdata/batch",
+          "xmlns$gd":"http://schemas.google.com/g/2005",
+          "gd$etag":"W/\"C0YHRno7fSt7I2A9WhBSQ0Q.\"",
+
+          "id":{"$t":"logged_in_user@gmail.com"},
+          "updated":{"$t":"2013-02-20T20:12:17.405Z"},
+          "category":[{
+            "scheme":"http://schemas.google.com/g/2005#kind",
+            "term":"http://schemas.google.com/contact/2008#contact"
+           }],
+
+          "title":{"$t":"Users\'s Contacts"},
+          "link":[
+            {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*",
+             "href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/6b41d030b05abc","gd$etag":"\"VSxuN0cISit7I2A1UVUSdy12KHwgBFkE333.\""},
+            {"rel":"alternate","type":"text/html","href":"http://www.google.com/"},
+            {"rel":"http://schemas.google.com/g/2005#feed","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full"},
+            {"rel":"http://schemas.google.com/g/2005#post","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full"},
+            {"rel":"http://schemas.google.com/g/2005#batch","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/batch"},
+            {"rel":"self","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full?alt\u003djson\u0026max-results\u003d1"},
+            {"rel":"next","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full?alt\u003djson\u0026start-index\u003d2\u0026max-results\u003d1"}
+          ],
+          "author":[{"name":{"$t":"Edward"},"email":{"$t":"logged_in_user@gmail.com"}}],
+          "generator":{"version":"1.0","uri":"http://www.google.com/m8/feeds","$t":"Contacts"},
+          "openSearch$totalResults":{"$t":"1007"},
+          "openSearch$startIndex":{"$t":"1"},
+          "openSearch$itemsPerPage":{"$t":"1"},
+          "entry":[
+            {
+            "gd$etag":"\"R3oyfDVSLyt7I2A9WhBTSEULRA0.\"",
+            "id":{"$t":"http://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/base/1"},
+            "updated":{"$t":"2013-02-14T22:36:36.494Z"},
+            "app$edited":{"xmlns$app":"http://www.w3.org/2007/app","$t":"2013-02-14T22:36:36.494Z"},
+            "category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://schemas.google.com/contact/2008#contact"}],
+            "title":{"$t":"Edward Bennet"},
+            "link":[
+              {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*",
+               "href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/6b41d030b05abc", "gd$etag":"\"VSxuN0cISit7I2A1UVUSdy12KHwgBFkE333.\""},
+              {"rel":"self","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"},
+              {"rel":"edit","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"}
+            ],
+            "gd$name":{
+              "gd$fullName":{"$t":"Edward Bennet"},
+              "gd$givenName":{"$t":"Edward"},
+              "gd$familyName":{"$t":"Bennet"}
+            },
+            "gd$organization":[{"rel":"http://schemas.google.com/g/2005#other","gd$orgName":{"$t":"Google"},"gd$orgTitle":{"$t":"Master Developer"}}],
+            "gContact$birthday":{"when":"1954-07-02"},
+            "gContact$relation":{"rel":"father"},
+            "gContact$gender":{"value":"male"},
+            "gContact$event":[{"rel":"anniversary","gd$when":{"startTime":"1983-04-21"}},{"label":"New Job","gd$when":{"startTime":"2014-12-01"}}],
+            "gd$email":[{"rel":"http://schemas.google.com/g/2005#other","address":"bennet@gmail.com","primary":"true"}],
+            "gContact$groupMembershipInfo":[{"deleted":"false","href":"http://www.google.com/m8/feeds/groups/logged_in_user%40gmail.com/base/6"}],
+            "gd$structuredPostalAddress":[{"rel":"http://schemas.google.com/g/2005#home","gd$formattedAddress":{},"gd$street":{},"gd$postcode":{"$t":"66666"},"gd$country":{"code":"VA","$t":"Valoran"},"gd$city":{"$t":"Nowheresville"},"gd$region":{"$t":"OK"}}],
+            "gd$phoneNumber":[{"rel":"http://schemas.google.com/g/2005#mobile","uri":"tel:+34-653-15-76-88","$t":"653157688"}]
+          },
+          {
+            "gd$etag":"\"R3oyfDVSLyt7I2A9WhBTSEULRA0.\"",
+            "id":{"$t":"http://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/base/1"},
+            "updated":{"$t":"2013-02-15T22:36:36.494Z"},
+            "app$edited":{"xmlns$app":"http://www.w3.org/2007/app","$t":"2013-02-15T22:36:36.494Z"},
+            "category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://schemas.google.com/contact/2008#contact"}],
+            "title":{"$t":"Emilia Fox"},
+            "link":[
+              {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*","href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/1"},
+              {"rel":"self","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"},
+              {"rel":"edit","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"}
+            ],
+            "gd$name":{
+              "gd$fullName":{"$t":"Emilia Fox"},
+              "gd$givenName":{"$t":"Emilia"},
+              "gd$familyName":{"$t":"Fox"}
+            },
+            "gContact$birthday":{"when":"1974-02-10"},
+            "gContact$relation":[{"rel":"spouse"}],
+            "gContact$gender":{"value":"female"},
+            "gd$email":[{"rel":"http://schemas.google.com/g/2005#other","address":"emilia.fox@gmail.com","primary":"true"}],
+            "gContact$groupMembershipInfo":[{"deleted":"false","href":"http://www.google.com/m8/feeds/groups/logged_in_user%40gmail.com/base/6"}]
+          }]
+        }
+      }'
+      }
+
+      it "should correctly parse id, name, email, gender, birthday, profile picture, snailmail address, phone and relation for 2nd contact" do
+        gmail.should_receive(:https_get)
+        gmail.should_receive(:https_get).and_return(contacts_as_json)
+        result = gmail.fetch_contacts_using_access_token token, token_type
+        result.size.should be(2)
+        result.last[:id].should eq('http://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/base/1')
+        result.last[:first_name].should eq('Emilia')
+        result.last[:last_name].should eq('Fox')
+        result.last[:name].should eq("Emilia Fox")
+        result.last[:email].should eq("emilia.fox@gmail.com")
+        result.last[:gender].should eq("female")
+        result.last[:birthday].should eq({ :day => 10, :month => 02, :year => 1974 })
+        result.last[:profile_picture].should be_nil
+        result.last[:relation].should eq('spouse')
+        result.first[:address_1].should eq(nil)
+        result.first[:address_2].should eq(nil)
+        result.first[:city].should eq('Nowheresville')
+        result.first[:region].should eq('OK')
+        result.first[:country].should eq('VA')
+        result.first[:postcode].should eq('66666')
+        result.first[:phone_number].should eq('653157688')
+      end
     end
   end
 end

--- a/spec/omnicontacts/importer/linkedin_spec.rb
+++ b/spec/omnicontacts/importer/linkedin_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+require "omnicontacts/importer/linkedin"
+
+describe OmniContacts::Importer::Linkedin do
+
+  let(:linkedin) { OmniContacts::Importer::Linkedin.new({}, "client_id", "client_secret", state: "ipsaeumeaque") }
+
+  let(:contacts_as_json) do
+    "{
+      \n  \"_total\":  2,
+      \n  \"values\":  [
+        \n    {
+          \n      \"firstName\":  \"Adolf\",
+          \n      \"id\":  \"k71S5q6MKe\",
+          \n      \"lastName\":  \"Witting\",
+          \n      \"pictureUrl\":  \"https://media.licdn.com/mpr/mprx/0_mLnj-7szw130pFRLB8Op7-p1Sxoyv53U3B47Scp1Sxoyv53U3B47Scp1Sxoyv53U3B47Sc\"\n
+        },
+        \n    {
+          \n      \"firstName\":  \"Emmet\",
+          \n      \"id\":  \"ms5r3lI3J2\",
+          \n      \"lastName\":  \"Little\",
+          \n      \"pictureUrl\":  \"https://media.licdn.com/mpr/mprx/0_iH9m158zCdISt1X6iH9m158zCdISt1X6iH9m158zCdISt1X6iH9m158zCdISt1X6iH9m158zCdISt1X6\"\n
+        }
+      ]\n
+    }"
+  end
+
+  describe "fetch_contacts_using_access_token" do
+    let(:token) { "token" }
+    let(:token_type) { nil }
+
+    before(:each) do
+      linkedin.instance_variable_set(:@env, {})
+    end
+
+    it "should request the contacts by specifying code in the http headers" do
+      linkedin.should_receive(:https_get) do |host, path, params, headers|
+        headers["Authorization"].should eq("Bearer #{token}")
+        contacts_as_json
+      end
+      linkedin.fetch_contacts_using_access_token token, token_type
+    end
+
+    it "should correctly parse id, name, and profile picture for 1st contact" do
+      linkedin.should_receive(:https_get).and_return(contacts_as_json)
+      result = linkedin.fetch_contacts_using_access_token token, token_type
+
+      result.size.should be(2)
+      result.first[:id].should eq('k71S5q6MKe')
+      result.first[:first_name].should eq('Adolf')
+      result.first[:last_name].should eq('Witting')
+      result.first[:name].should eq("Adolf Witting")
+      result.first[:profile_picture].should eq("https://media.licdn.com/mpr/mprx/0_mLnj-7szw130pFRLB8Op7-p1Sxoyv53U3B47Scp1Sxoyv53U3B47Scp1Sxoyv53U3B47Sc")
+    end
+
+    it "should correctly parse id, name, and profile picture for 2nd contact" do
+      linkedin.should_receive(:https_get).and_return(contacts_as_json)
+      result = linkedin.fetch_contacts_using_access_token token, token_type
+      result.size.should be(2)
+      result.last[:id].should eq('ms5r3lI3J2')
+      result.last[:first_name].should eq('Emmet')
+      result.last[:last_name].should eq('Little')
+      result.last[:name].should eq("Emmet Little")
+      result.last[:profile_picture].should eq("https://media.licdn.com/mpr/mprx/0_iH9m158zCdISt1X6iH9m158zCdISt1X6iH9m158zCdISt1X6iH9m158zCdISt1X6iH9m158zCdISt1X6")
+    end
+  end
+end

--- a/spec/omnicontacts/importer/outlook_spec.rb
+++ b/spec/omnicontacts/importer/outlook_spec.rb
@@ -1,0 +1,150 @@
+require "spec_helper"
+require "omnicontacts/importer/outlook"
+
+describe OmniContacts::Importer::Outlook do
+
+  let(:permissions) { "Contacts.Read" }
+  let(:outlook) { OmniContacts::Importer::Outlook.new({}, "app_id", "app_secret", {:permissions => permissions}) }
+
+  let(:self_response) {
+    '{
+      "@odata.context": "https://outlook.office.com/api/v2.0/$metadata#Me",
+      "@odata.id": "https://outlook.office.com/api/v2.0/Users(\'00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa\')",
+      "Id": "00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa",
+      "EmailAddress": "test.user@outlook.com",
+      "DisplayName": "Test User",
+      "Alias": "puid-00034001DF52D3D5",
+      "MailboxGuid": "00034001-df52-d3d5-0000-000000000000"
+    }'
+  }
+
+  let(:contacts_as_json) {
+    '{
+      "@odata.context": "https://outlook.office.com/api/v2.0/$metadata#Me/Contacts",
+      "value": [{
+        "@odata.id": "https://outlook.office.com/api/v2.0/Users(\'00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa\')/Contacts(\'AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgBGAAADQ1hAWLJpwk6DZYyOhnclvgcAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAAxCL3G7jnpkiRUVmiNrhjJgAAAixsAAAA\')",
+        "@odata.etag": "W/\"EQAAABYAAADEIvcbuOemSJFRWaI2uGMmAAAAlo4t\"",
+        "Id": "AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgBGAAADQ1hAWLJpwk6DZYyOhnclvgcAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAAxCL3G7jnpkiRUVmiNrhjJgAAAixsAAAA",
+        "CreatedDateTime": "2016-04-13T21:25:24Z",
+        "LastModifiedDateTime": "2016-04-14T19:36:55Z",
+        "ChangeKey": "EQAAABYAAADEIvcbuOemSJFRWaI2uGMmAAAAlo4t",
+        "Categories": [],
+        "ParentFolderId": "AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgAuAAADQ1hAWLJpwk6DZYyOhnclvgEAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAA",
+        "Birthday": "1604-08-14T00:00:00Z",
+        "FileAs": "Contact, First",
+        "DisplayName": "First Contact",
+        "GivenName": "First",
+        "Initials": null,
+        "MiddleName": null,
+        "NickName": null,
+        "Surname": "Contact",
+        "Title": null,
+        "YomiGivenName": null,
+        "YomiSurname": null,
+        "YomiCompanyName": null,
+        "Generation": null,
+        "EmailAddresses": [{
+          "Name": "contact.first@email.com",
+          "Address": "contact.first@email.com"
+        }, {
+          "Name": "contact.second@email.com",
+          "Address": "contact.second@email.com"
+        }],
+        "ImAddresses": [],
+        "JobTitle": null,
+        "CompanyName": null,
+        "Department": null,
+        "OfficeLocation": null,
+        "Profession": null,
+        "BusinessHomePage": null,
+        "AssistantName": null,
+        "Manager": null,
+        "HomePhones": [],
+        "MobilePhone1": null,
+        "BusinessPhones": [],
+        "HomeAddress": {
+          "Street": "address1",
+          "City": "city",
+          "State": "state",
+          "CountryOrRegion": "US",
+          "PostalCode": "89111"
+        },
+        "BusinessAddress": {},
+        "OtherAddress": {},
+        "SpouseName": null,
+        "PersonalNotes": null,
+        "Children": []
+      }]
+    }'
+  }
+
+  describe "fetch_contacts_using_access_token" do
+
+    let(:access_token) { "access_token" }
+    let(:token_type) { "token_type" }
+
+    before(:each) do
+      outlook.instance_variable_set(:@env, {"HTTP_HOST" => "http://example.com"})
+    end
+
+    it "should request the contacts by providing the authorization header with token_type and access_token" do
+      outlook.should_receive(:https_get) do |host, path, params, headers|
+        params.should eq({})
+        headers["Authorization"].should eq("token_type access_token")
+        self_response
+      end
+
+      outlook.should_receive(:https_get) do |host, path, params, headers|
+        params.should eq({})
+        headers["Authorization"].should eq("token_type access_token")
+        contacts_as_json
+      end
+      outlook.fetch_contacts_using_access_token access_token, token_type
+    end
+
+    it "should set requested permissions in the authorization url" do
+      outlook.authorization_url.should match(/scope=#{Regexp.quote(CGI.escape(permissions))}/)
+    end
+
+    it "should correctly parse id, name and email" do
+      outlook.should_receive(:https_get).and_return(self_response)
+      outlook.should_receive(:https_get).and_return(contacts_as_json)
+      result = outlook.fetch_contacts_using_access_token access_token, token_type
+
+      result.size.should be(1)
+      result.first[:id].should eq('AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgBGAAADQ1hAWLJpwk6DZYyOhnclvgcAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAAxCL3G7jnpkiRUVmiNrhjJgAAAixsAAAA')
+      result.first[:first_name].should eq("First")
+      result.first[:last_name].should eq("Contact")
+      result.first[:name].should eq("First Contact")
+      result.first[:email].should eq("contact.first@email.com")
+      result.first[:birthday].should eq({ :day => 14, :month => 8, :year => nil })
+      result.first[:address_1].should eq("address1")
+      result.first[:address_2].should be_nil
+      result.first[:city].should eq("city")
+      result.first[:region].should eq("state")
+      result.first[:postcode].should eq("89111")
+      result.first[:country].should eq("US")
+      result.first[:gender].should be_nil
+      result.first[:profile_picture].should be_nil
+      result.first[:relation].should be_nil
+    end
+
+    it "should correctly parse and set logged in user information" do
+      outlook.should_receive(:https_get).and_return(self_response)
+      outlook.should_receive(:https_get).and_return(contacts_as_json)
+
+      outlook.fetch_contacts_using_access_token access_token, token_type
+
+      user = outlook.instance_variable_get(:@env)["omnicontacts.user"]
+      user.should_not be_nil
+      user[:id].should eq('00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa')
+      user[:first_name].should eq("Test")
+      user[:last_name].should eq("User")
+      user[:name].should eq("Test User")
+      user[:email].should eq("test.user@outlook.com")
+      user[:gender].should be_nil
+      user[:birthday].should be_nil
+    end
+  end
+
+end

--- a/spec/omnicontacts/integration_test_spec.rb
+++ b/spec/omnicontacts/integration_test_spec.rb
@@ -11,7 +11,7 @@ describe IntegrationTest do
       IntegrationTest.instance.mock_authorization_from_user(provider)[1]["location"].should eq(redirect_path)
     end
   end
-  
+
   context "mock_callback" do
 
     before(:each) {
@@ -20,11 +20,11 @@ describe IntegrationTest do
       @provider.stub(:class_name => "test")
       IntegrationTest.instance.clear_mocks
     }
-    
+
     it "should return an empty contacts list" do
       IntegrationTest.instance.mock_fetch_contacts(@provider).should be_empty
     end
-    
+
     it "should return a configured list of contacts " do
       contacts = [:name => 'John Doe', :email => 'john@doe.com']
       IntegrationTest.instance.mock('test', contacts)
@@ -42,7 +42,16 @@ describe IntegrationTest do
       result.first[:email].should eq(contact[:email])
       result.first[:name].should eq(contact[:name])
     end
-    
+
+    it "should return a user" do
+      contact = {:name => 'John Doe', :email => 'john@doe.com'}
+      user = {:name => 'Mary Smith', :email => 'mary@smith.com'}
+      IntegrationTest.instance.mock('test', contact, user)
+      result = IntegrationTest.instance.mock_fetch_user(@provider)
+      result[:email].should eq(user[:email])
+      result[:name].should eq(user[:name])
+    end
+
     it "should throw an exception" do
       IntegrationTest.instance.mock('test', :some_error)
       expect {IntegrationTest.instance.mock_fetch_contacts(@provider)}.to raise_error

--- a/spec/omnicontacts/middleware/base_oauth_spec.rb
+++ b/spec/omnicontacts/middleware/base_oauth_spec.rb
@@ -13,6 +13,14 @@ describe OmniContacts::Middleware::BaseOAuth do
       def redirect_path
         "#{ MOUNT_PATH }testprovider/callback"
       end
+
+      def self.mock_session
+        @mock_session ||= {}
+      end
+
+      def session
+        TestProvider.mock_session
+      end
     end
     OmniContacts.integration_test.enabled = true
   end
@@ -31,7 +39,7 @@ describe OmniContacts::Middleware::BaseOAuth do
     last_request.env["omnicontacts.contacts"].first[:email].should eq("user@example.com")
   end
 
-  it "should redurect to failure url" do
+  it "should redirect to failure url" do
     OmniContacts.integration_test.mock(:testprovider, "some_error" )
     get "#{ MOUNT_PATH }testprovider"
     get "#{MOUNT_PATH }testprovider/callback"
@@ -44,10 +52,31 @@ describe OmniContacts::Middleware::BaseOAuth do
     get "#{MOUNT_PATH }testprovider/callback?state=/parent/resource/id"
     last_response.headers["location"].should eq("#{ MOUNT_PATH }failure?error_message=internal_error&importer=testprovider&state=/parent/resource/id")
   end
+
+  it "should store request params in session" do
+    OmniContacts.integration_test.mock(:testprovider, :email => "user@example.com")
+    get "#{ MOUNT_PATH }testprovider?foo=bar"
+    app.session['omnicontacts.params'].should eq({'foo' => 'bar'})
+  end
+
+  it "should pass the params from session to callback environment " do
+    OmniContacts.integration_test.mock(:testprovider, :email => "user@example.com")
+    app.session.merge!({'omnicontacts.params' => {'foo' => 'bar'}})
+    get "#{MOUNT_PATH }testprovider/callback?state=/parent/resource/id"
+    last_request.env["omnicontacts.params"].should eq({'foo' => 'bar'})
+  end
+
+  it "should pass the params from session on failure" do
+    OmniContacts.integration_test.mock(:testprovider, "some_error" )
+    get "#{ MOUNT_PATH }testprovider"
+    app.session.merge!({'omnicontacts.params' => {'foo' => 'bar'}})
+    get "#{MOUNT_PATH }testprovider/callback"
+    last_response.should be_redirect
+    last_response.headers["location"].should be_include("foo=bar")
+  end
   
   after(:all) do 
     OmniContacts.integration_test.enabled = false
     OmniContacts.integration_test.clear_mocks
   end
-  
 end

--- a/spec/omnicontacts/parse_utils_spec.rb
+++ b/spec/omnicontacts/parse_utils_spec.rb
@@ -21,5 +21,33 @@ describe OmniContacts::ParseUtils do
       result = full_name("John", "McDonald")
       result.should eq("John McDonald")
     end
+
+    it "returns only first name if no last name present" do
+      result = full_name("John", nil)
+      result.should eq("John")
+    end
+
+    it "returns only last name if no first name present" do
+      result = full_name(nil, "McDonald")
+      result.should eq("McDonald")
+    end
+  end
+
+  describe "birthday_format" do
+    it "returns nil if (!year && !month) || (!year && !day)" do
+      result = birthday_format(nil, Date.today, nil)
+      result.should eq(nil)
+
+      result = birthday_format(Date.today.month, nil, nil)
+      result.should eq(nil)
+    end
+  end
+
+  describe "email_to_name" do
+    it "create a probable name from email" do
+      username_or_email = "foo.bar@test.com"
+      result = email_to_name(username_or_email)
+      result.should eq ['foo','bar',"foo bar"]
+    end
   end
 end


### PR DESCRIPTION
Rails 5 now uses rack 2.x which was causing builder.rb’s initialize & call methods to behave as if it were a legacy rack version.

Added a check for rack 2.x and where appropriate.